### PR TITLE
Allow links to open in html documents

### DIFF
--- a/src/components/contents/html.js
+++ b/src/components/contents/html.js
@@ -19,7 +19,7 @@ export default class HTMLView extends React.Component<*> {
       >
         <iframe
           title={`view of ${this.props.entry.path}`}
-          sandbox="allow-scripts"
+          sandbox="allow-scripts allow-popups allow-same-origin"
           style={{
             width: "100%",
             height: "100%",


### PR DESCRIPTION
When viewing a html document in commuter (such as a html rendered from a notebook through nbconvert), any links in the document will fail to open with an error like

```
about:srcdoc:1 Blocked opening 'https://example.com/' in a new window because the request was made in a sandboxed frame whose 'allow-popups' permission is not set.
```

This PR changes the Iframe permissions to allow links to work. Any concerns with this? Thanks!